### PR TITLE
Bugfix for - TC_17

### DIFF
--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -21,7 +21,7 @@
 					<% render partial: 'comments', locals: {comments: @object_issues.CommentsArray } %>
 				<% end %>
 			</div>
-
+		<%= link_to 'Back', :back, class: 'btn btn-primary' %>
 		</div>  
 	</div>
 </div>


### PR DESCRIPTION
Fixed Bug TC_17.
The Cut Detail page does not have the Close button.
Please see the attached screenshot, in the case of any preferences in terms of Button colour/alignment/positioning.
![back_button_dbtc](https://cloud.githubusercontent.com/assets/7137309/16872290/91360d90-4aa9-11e6-9f24-9840ce56cf2f.png)